### PR TITLE
Fix issue with failures on AIX platform.

### DIFF
--- a/lib/poise_service/service_providers/base.rb
+++ b/lib/poise_service/service_providers/base.rb
@@ -149,7 +149,7 @@ module PoiseService
         # Sigh scoping.
         template path do
           owner 'root'
-          group 'root'
+          group node['root_group']
           mode '644'
           if options['template']
             # If we have a template override, allow specifying a cookbook via


### PR DESCRIPTION
/cc @coderanger

If we want to use sysvinit provider explicitly on the AIX platform this
fails due to the root group not existing. Let's use the Ohai attribute
to determine the default group.