### PR TITLE
Run systemctyl daemon-reload after the service is deleted

### DIFF
--- a/lib/poise_service/service_providers/systemd.rb
+++ b/lib/poise_service/service_providers/systemd.rb
@@ -75,7 +75,9 @@ module PoiseService
       end
 
       def destroy_service
+        reloader = systemctl_daemon_reload
         file "/etc/systemd/system/#{new_resource.service_name}.service" do
+          notifies :run, reloader, :immediately if options['auto_reload']
           action :delete
         end
       end


### PR DESCRIPTION
Hi,
Changed the SystemD provider to run `systemctl daemon-reload` after deleting the service file.  Otherwise, tests using inspec (and maybe others) fail because it sees the service as still existing after the delete.