### PR TITLE
Adding Amazon to the Redhat service provider for Sys-V

### DIFF
--- a/lib/poise_service/service_providers/sysvinit.rb
+++ b/lib/poise_service/service_providers/sysvinit.rb
@@ -37,7 +37,7 @@ module PoiseService
           r.provider(case node['platform_family']
           when 'debian'
             Chef::Provider::Service::Debian
-          when 'rhel'
+          when 'rhel', 'amazon'
             Chef::Provider::Service::Redhat
           else
             # Better than nothing I guess? Will fail on enable I think.


### PR DESCRIPTION
As per this commit. It looks like Amazon should be included in the sys-v camp
https://github.com/poise/poise-service/blob/master/lib/poise_service/service_providers/sysvinit.rb#L40
Related to: https://github.com/sous-chefs/haproxy/issues/214